### PR TITLE
style(blueprints): update imports to respect Style 03-06

### DIFF
--- a/packages/angular-cli/blueprints/ng2/files/__path__/main.ts
+++ b/packages/angular-cli/blueprints/ng2/files/__path__/main.ts
@@ -1,9 +1,10 @@
 import './polyfills.ts';
 
-import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
 import { enableProdMode } from '@angular/core';
-import { environment } from './environments/environment';
+import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
+
 import { AppModule } from './app/app.module';
+import { environment } from './environments/environment';
 
 if (environment.production) {
   enableProdMode();


### PR DESCRIPTION
From [Style 03-06](https://angular.io/styleguide#!#03-06) guideline:
- Consider leaving one empty line between third party imports and application imports.
- Consider listing import lines alphabetized by the module.
